### PR TITLE
feat(F1.5): outbox genérico — dispatcher extensível com handler registry

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,57 @@
+# ── Projeto ───────────────────────────────────────────────────────────────────
+PROJECT_NAME=Normatiq
+DEBUG=false
+
+# ── Banco de dados ────────────────────────────────────────────────────────────
+POSTGRES_USER=normatiq
+POSTGRES_PASSWORD=TROQUE_POR_SENHA_FORTE
+POSTGRES_DB=normatiq
+DATABASE_URL=postgresql+asyncpg://normatiq:TROQUE_POR_SENHA_FORTE@postgres:5432/normatiq
+
+# ── JWT ───────────────────────────────────────────────────────────────────────
+# Gerar: python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=TROQUE_POR_SECRET_KEY_ALEATORIA
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# ── Admin global (superadmin) ─────────────────────────────────────────────────
+ADMIN_DEFAULT_USERNAME=admin
+ADMIN_DEFAULT_PASSWORD=TROQUE_POR_SENHA_FORTE
+
+# ── Tenant e usuário inicial do dono ─────────────────────────────────────────
+OWNER_EMAIL=admin@z3ndocs.uk
+OWNER_PASSWORD=TROQUE_POR_SENHA_FORTE
+OWNER_TENANT_NAME=Normatiq Lab
+OWNER_TENANT_SLUG=normatiq
+
+# ── Criptografia de campos sensíveis ─────────────────────────────────────────
+# Gerar: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+ENCRYPTION_KEY=TROQUE_POR_FERNET_KEY
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+REDIS_URL=redis://redis:6379/0
+
+# ── E-mail (SMTP real em prod — ex: Mailgun, Resend, SES) ────────────────────
+SMTP_HOST=smtp.seuservidor.com
+SMTP_PORT=587
+SMTP_USER=apikey
+SMTP_PASSWORD=SUA_CHAVE_SMTP
+EMAIL_FROM=noreply@z3ndocs.uk
+
+# ── MinIO / S3 ────────────────────────────────────────────────────────────────
+S3_ENDPOINT_URL=http://minio:9000
+S3_ACCESS_KEY=TROQUE_POR_ACCESS_KEY
+S3_SECRET_KEY=TROQUE_POR_SECRET_KEY
+S3_BUCKET=normatiq
+S3_REGION=us-east-1
+
+# ── Trial padrão ──────────────────────────────────────────────────────────────
+DEFAULT_TRIAL_DAYS=30
+
+# ── Frontend ──────────────────────────────────────────────────────────────────
+FRONTEND_URL=https://z3ndocs.uk
+
+# ── Flower (basicauth para o dashboard Celery) ────────────────────────────────
+# Gerar: echo $(htpasswd -nb admin SUA_SENHA) | sed 's/\$/\$\$/g'
+FLOWER_BASICAUTH=admin:$$apr1$$HASH_AQUI

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: 🚀 Deploy to Production
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            set -e
+            cd ${{ secrets.PROD_PATH }}
+
+            echo "==> Atualizando código..."
+            git pull origin main
+
+            echo "==> Rebuilding imagens..."
+            docker compose -f docker-compose.prod.yml build
+
+            echo "==> Subindo containers..."
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+            echo "==> Limpando imagens antigas..."
+            docker image prune -f
+
+            echo "==> Deploy concluído."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: help up down restart logs build shell db-migrate db-seed test clean
+.PHONY: help up down restart logs build shell db-migrate db-seed test clean \
+        prod-up prod-down prod-logs prod-build prod-migrate prod-shell
 
 # Variáveis
-DC = docker compose
+DC      = docker compose
+DC_PROD = docker compose -f docker-compose.prod.yml
 APP_SERVICE = api
 
 help: ## Mostra esta ajuda
@@ -34,12 +36,8 @@ db-makemigrations: ## Gera uma nova migração (uso: make db-makemigrations msg=
 db-seed: ## Executa o script de seed inicial
 	$(DC) exec $(APP_SERVICE) /entrypoint.sh
 
-lint: ## Executa a verificação de lint e formatação (Ruff)
-	$(DC) exec $(APP_SERVICE) /app/.venv/bin/ruff check . --fix
-	$(DC) exec $(APP_SERVICE) /app/.venv/bin/ruff format .
-
-test: lint ## Executa o lint e depois os testes automatizados
-	$(DC) exec $(APP_SERVICE) /app/.venv/bin/python -m pytest
+test: ## Executa os testes automatizados
+	$(DC) exec $(APP_SERVICE) uv run python -m pytest
 
 logs-f: ## Exibe os logs do frontend
 	$(DC) logs -f frontend
@@ -49,3 +47,22 @@ rf: ## Reinicia rapidamente o frontend para aplicar mudanças de código
 
 clean: ## Remove volumes e imagens órfãs
 	$(DC) down -v --remove-orphans
+
+# ── Produção ──────────────────────────────────────────────────────────────────
+prod-up: ## [prod] Sobe os containers de produção
+	$(DC_PROD) up -d
+
+prod-down: ## [prod] Para os containers de produção
+	$(DC_PROD) down
+
+prod-build: ## [prod] Reconstrói as imagens de produção
+	$(DC_PROD) build --no-cache
+
+prod-logs: ## [prod] Exibe os logs de produção
+	$(DC_PROD) logs -f
+
+prod-migrate: ## [prod] Executa migrações em produção
+	$(DC_PROD) exec api uv run alembic upgrade head
+
+prod-shell: ## [prod] Abre shell no container da API em produção
+	$(DC_PROD) exec api /bin/bash

--- a/backend/app/core/celery.py
+++ b/backend/app/core/celery.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+
 from celery import Celery
+
 from app.core.settings import settings
 
 logger = logging.getLogger("worker")
@@ -28,44 +30,41 @@ celery_app.conf.update(
 
 @celery_app.task(name="app.core.celery.process_outbox")
 def process_outbox():
-    """Tarefa Celery para processar eventos de outbox pendentes."""
+    """Tarefa Celery que processa eventos pendentes do outbox."""
     return asyncio.run(_run_process_outbox())
 
 
-async def _run_process_outbox():
+async def _run_process_outbox() -> str:
+    import app.domains.outbox.handlers  # noqa: F401 — registra todos os handlers
+
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.domains.outbox.dispatcher import dispatch
     from app.domains.outbox.repository import OutboxRepository
-    from app.domains.outbox.model import OutboxEventType
-    from app.core.email import email_service
 
     engine = create_async_engine(settings.DATABASE_URL)
     SessionFactory = async_sessionmaker(engine, expire_on_commit=False)
 
+    processed = 0
+    failed = 0
+
     async with SessionFactory() as session:
         repo = OutboxRepository(session)
-        events = await repo.get_pending(limit=5)
-
-        if not events:
-            return "No pending events"
+        events = await repo.get_pending(limit=10)
 
         for event in events:
             try:
-                if event.event_type == OutboxEventType.USER_INVITE:
-                    email_service.send_user_invite(
-                        email=event.payload["email"],
-                        nome=event.payload["nome"],
-                        token=event.payload["token"],
-                    )
-
+                await dispatch(event)
                 await repo.mark_processed(event.id)
                 await session.commit()
-                logger.info(f"Evento {event.id} processado com sucesso.")
-
-            except Exception as e:
+                logger.info("Evento %s (%s) processado.", event.id, event.event_type)
+                processed += 1
+            except Exception as exc:
                 await session.rollback()
-                await repo.mark_failed(event.id, str(e))
+                await repo.mark_failed(event.id, str(exc))
                 await session.commit()
-                logger.error(f"Falha ao processar evento {event.id}: {e}")
+                logger.error("Falha no evento %s: %s", event.id, exc)
+                failed += 1
 
     await engine.dispose()
-    return f"Processed {len(events)} events"
+    return f"processed={processed} failed={failed}"

--- a/backend/app/domains/outbox/dispatcher.py
+++ b/backend/app/domains/outbox/dispatcher.py
@@ -1,9 +1,8 @@
 from collections.abc import Awaitable, Callable
-from typing import TypeAlias
 
 from app.domains.outbox.model import OutboxEvent, OutboxEventType
 
-Handler: TypeAlias = Callable[[OutboxEvent], Awaitable[None]]
+type Handler = Callable[[OutboxEvent], Awaitable[None]]
 
 _registry: dict[OutboxEventType, Handler] = {}
 

--- a/backend/app/domains/outbox/dispatcher.py
+++ b/backend/app/domains/outbox/dispatcher.py
@@ -1,0 +1,30 @@
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+
+from app.domains.outbox.model import OutboxEvent, OutboxEventType
+
+Handler: TypeAlias = Callable[[OutboxEvent], Awaitable[None]]
+
+_registry: dict[OutboxEventType, Handler] = {}
+
+
+def register(event_type: OutboxEventType) -> Callable[[Handler], Handler]:
+    """Decorator que registra um handler para um tipo de evento do outbox."""
+
+    def decorator(fn: Handler) -> Handler:
+        _registry[event_type] = fn
+        return fn
+
+    return decorator
+
+
+async def dispatch(event: OutboxEvent) -> None:
+    """Despacha um evento para o handler registrado.
+
+    Raises:
+        ValueError: se nenhum handler estiver registrado para o tipo do evento.
+    """
+    handler = _registry.get(event.event_type)
+    if handler is None:
+        raise ValueError(f"Nenhum handler registrado para {event.event_type!r}")
+    await handler(event)

--- a/backend/app/domains/outbox/handlers/__init__.py
+++ b/backend/app/domains/outbox/handlers/__init__.py
@@ -1,0 +1,11 @@
+"""
+Importar este pacote garante que todos os handlers sejam registrados no dispatcher.
+
+Para adicionar um novo handler:
+  1. Adicionar o valor em OutboxEventType (model.py)
+  2. Criar (ou adicionar em) um módulo neste diretório
+  3. Decorar a função com @register(OutboxEventType.NOVO_TIPO)
+  4. Importar o módulo abaixo — o worker não precisa de nenhuma alteração.
+"""
+
+from app.domains.outbox.handlers import auth  # noqa: F401

--- a/backend/app/domains/outbox/handlers/auth.py
+++ b/backend/app/domains/outbox/handlers/auth.py
@@ -1,0 +1,15 @@
+import asyncio
+
+from app.core.email import email_service
+from app.domains.outbox.dispatcher import register
+from app.domains.outbox.model import OutboxEvent, OutboxEventType
+
+
+@register(OutboxEventType.USER_INVITE)
+async def handle_user_invite(event: OutboxEvent) -> None:
+    await asyncio.to_thread(
+        email_service.send_user_invite,
+        email=event.payload["email"],
+        nome=event.payload["nome"],
+        token=event.payload["token"],
+    )

--- a/backend/tests/test_outbox_dispatcher.py
+++ b/backend/tests/test_outbox_dispatcher.py
@@ -1,7 +1,5 @@
 """Testes unitários do dispatcher de outbox (handler registry)."""
 
-import uuid
-from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -19,7 +17,9 @@ def isolate_registry():
     _registry.update(snapshot)
 
 
-def _make_event(event_type: OutboxEventType, payload: dict | None = None) -> OutboxEvent:
+def _make_event(
+    event_type: OutboxEventType, payload: dict | None = None
+) -> OutboxEvent:
     return OutboxEvent(
         event_type=event_type,
         payload=payload or {},

--- a/backend/tests/test_outbox_dispatcher.py
+++ b/backend/tests/test_outbox_dispatcher.py
@@ -1,0 +1,109 @@
+"""Testes unitários do dispatcher de outbox (handler registry)."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.domains.outbox.dispatcher import _registry, dispatch, register
+from app.domains.outbox.model import OutboxEvent, OutboxEventType, OutboxStatus
+
+
+@pytest.fixture(autouse=True)
+def isolate_registry():
+    """Restaura o registry ao estado original após cada teste."""
+    snapshot = dict(_registry)
+    yield
+    _registry.clear()
+    _registry.update(snapshot)
+
+
+def _make_event(event_type: OutboxEventType, payload: dict | None = None) -> OutboxEvent:
+    return OutboxEvent(
+        event_type=event_type,
+        payload=payload or {},
+        status=OutboxStatus.PENDING,
+    )
+
+
+# ── Dispatcher ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_chama_handler_registrado():
+    handler = AsyncMock()
+    register(OutboxEventType.USER_INVITE)(handler)
+
+    event = _make_event(OutboxEventType.USER_INVITE)
+    await dispatch(event)
+
+    handler.assert_awaited_once_with(event)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_levanta_para_tipo_sem_handler():
+    _registry.pop(OutboxEventType.USER_INVITE, None)
+
+    event = _make_event(OutboxEventType.USER_INVITE)
+    with pytest.raises(ValueError, match="Nenhum handler registrado"):
+        await dispatch(event)
+
+
+@pytest.mark.asyncio
+async def test_register_substitui_handler_existente():
+    first = AsyncMock()
+    second = AsyncMock()
+
+    register(OutboxEventType.USER_INVITE)(first)
+    register(OutboxEventType.USER_INVITE)(second)
+
+    event = _make_event(OutboxEventType.USER_INVITE)
+    await dispatch(event)
+
+    second.assert_awaited_once_with(event)
+    first.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_handlers_independentes_por_tipo():
+    invite_handler = AsyncMock()
+    reset_handler = AsyncMock()
+
+    register(OutboxEventType.USER_INVITE)(invite_handler)
+    register(OutboxEventType.PASSWORD_RESET)(reset_handler)
+
+    invite_event = _make_event(OutboxEventType.USER_INVITE)
+    reset_event = _make_event(OutboxEventType.PASSWORD_RESET)
+
+    await dispatch(invite_event)
+    await dispatch(reset_event)
+
+    invite_handler.assert_awaited_once_with(invite_event)
+    reset_handler.assert_awaited_once_with(reset_event)
+
+
+# ── Handler de auth ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_user_invite_chama_email_service():
+    import app.domains.outbox.handlers.auth  # noqa: F401 — garante registro
+
+    payload = {
+        "email": "user@test.com",
+        "nome": "Fulano",
+        "token": "abc123",
+    }
+    event = _make_event(OutboxEventType.USER_INVITE, payload)
+
+    with patch(
+        "app.domains.outbox.handlers.auth.email_service.send_user_invite"
+    ) as mock_send:
+        await dispatch(event)
+
+    mock_send.assert_called_once_with(
+        email="user@test.com",
+        nome="Fulano",
+        token="abc123",
+    )

--- a/compose/dev/api/Dockerfile
+++ b/compose/dev/api/Dockerfile
@@ -21,8 +21,8 @@ COPY backend/app/ ./app/
 COPY backend/alembic/ ./alembic/
 COPY backend/alembic.ini ./
 
-# Sincroniza o projeto final (incluindo dev para testes)
-RUN uv sync
+# Sincroniza o projeto final (incluindo dependências dev para testes)
+RUN uv sync --extra dev
 
 # Copia o entrypoint da pasta de composição
 COPY compose/dev/api/entrypoint.sh /entrypoint.sh

--- a/compose/prod/api/Dockerfile
+++ b/compose/prod/api/Dockerfile
@@ -1,61 +1,24 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 
-# Instala dependências do sistema:
-#   nodejs/npm → servidores MCP via npx
-#   ffmpeg     → conversão WAV→OGG/OPUS para TTS (Piper)
-#   libgomp1   → requerido pelo faster-whisper (OpenMP)
-#   wget       → download de modelos Piper no build
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    nodejs \
-    npm \
-    ffmpeg \
-    libgomp1 \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# Instala o uv e uvx (gerenciador de pacotes e executor de tools)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 
-# Copia apenas os arquivos de dependencias primeiro (cache de camadas)
-COPY pyproject.toml uv.lock ./
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
 
-# Instala dependencias de producao (sem dev)
+# Camada de cache: instala dependências antes de copiar o código
+COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --no-dev --frozen
 
-# Copia o codigo fonte
-COPY src/ ./src/
+# Código fonte e migrações
+COPY backend/app/ ./app/
+COPY backend/alembic/ ./alembic/
+COPY backend/alembic.ini ./
 
-# Copia os servidores MCP customizados
-COPY mcp_servers/ ./mcp_servers/
-
-# Copia o entrypoint de prod (roda Alembic + seed)
 COPY compose/prod/api/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
-# Cria diretorios de dados e modelos
-RUN mkdir -p data/pdfs data/chroma_db models/piper
-
-# ── Pré-download: modelo Whisper base ────────────────────────────────────────
-# HF_HOME aponta para dentro do container (persistido via volume se necessário)
-ENV HF_HOME=/app/models/huggingface
-RUN uv run python -c "\
-from faster_whisper import WhisperModel; \
-print('Baixando modelo Whisper base...'); \
-WhisperModel('base', device='cpu', compute_type='int8'); \
-print('Whisper base OK')"
-
-# ── Pré-download: modelo Piper pt_BR-faber-medium ────────────────────────────
-ENV PIPER_MODELS_DIR=/app/models/piper
-RUN wget -q \
-    "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/pt/pt_BR/faber/medium/pt_BR-faber-medium.onnx" \
-    -O /app/models/piper/pt_BR-faber-medium.onnx && \
-    wget -q \
-    "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/pt/pt_BR/faber/medium/pt_BR-faber-medium.onnx.json" \
-    -O /app/models/piper/pt_BR-faber-medium.onnx.json && \
-    echo "Piper pt_BR-faber-medium OK"
 
 EXPOSE 8000
 

--- a/compose/prod/api/entrypoint.sh
+++ b/compose/prod/api/entrypoint.sh
@@ -1,163 +1,90 @@
 #!/bin/bash
 set -e
 
-if [ "${SKIP_MIGRATIONS:-false}" = "true" ]; then
-  echo "[entrypoint] SKIP_MIGRATIONS=true — pulando migrações e seed."
-  exec "$@"
-fi
-
 echo "[entrypoint] Rodando migrações Alembic..."
 uv run alembic upgrade head
 echo "[entrypoint] Migrações aplicadas."
 
-echo "[entrypoint] Executando seed de dados iniciais..."
-
+echo "[entrypoint] Rodando seed inicial..."
 uv run python -c "
-import asyncio, sys
-sys.path.insert(0, '/app/src')
-from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+import asyncio
 from sqlalchemy import select
-from app.database import Base
-from app.tenant.models import Tenant
-from app.usuario.models import Usuario, UsuarioRole
-from app.telegram.models import TelegramInstancia  # noqa
-from app.whatsapp.models import WhatsappInstancia  # noqa
-from app.atendimento.models import Atendimento, MensagemAtendimento, Contato  # noqa
-from app.mcp_server.models import McpServer, McpTool  # noqa
-from app.agente.models import Agente, Documento  # noqa
-from app.admin.models import Admin  # noqa
-from app.system_config.models import SystemConfig  # noqa
-from app.agente.defaults import AGENTES_PADRAO
-from app.auth.security import get_password_hash
-from app.settings import Settings
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from app.core.settings import settings
+from app.core.security import get_password_hash
+from app.core.database import Base
 
-settings = Settings()
-username = settings.ADMIN_DEFAULT_USERNAME
-password = settings.ADMIN_DEFAULT_PASSWORD
+from app.domains.plans.model import Plan
+from app.domains.tenants.model import Tenant, TenantStatus
+from app.domains.users.model import User, UserRole
+from app.domains.subscriptions.model import Subscription
+from app.domains.admin.model import Admin
 
 async def main():
-    engine = create_async_engine(settings.DOCAGENT_DB_URL)
-    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    engine = create_async_engine(settings.DATABASE_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
 
-    async with SessionLocal() as session:
+    async with Session() as session:
         async with session.begin():
-            result = await session.execute(select(Usuario).where(Usuario.username == username))
-            existing = result.scalar_one_or_none()
-            if existing:
-                print(f'[entrypoint] Usuário {username!r} já existe, pulando seed de usuário.')
+            result = await session.execute(
+                select(Admin).where(Admin.username == settings.ADMIN_DEFAULT_USERNAME)
+            )
+            admin = result.scalar_one_or_none()
+
+            if not admin:
+                session.add(Admin(
+                    username=settings.ADMIN_DEFAULT_USERNAME,
+                    email=settings.OWNER_EMAIL,
+                    password=get_password_hash(settings.ADMIN_DEFAULT_PASSWORD),
+                    nome='Super Administrador',
+                    ativo=True,
+                ))
+                print(f'[seed] Admin {settings.ADMIN_DEFAULT_USERNAME!r} criado.')
             else:
-                tenant = Tenant(nome='Admin Tenant', descricao='Tenant padrão')
+                admin.password = get_password_hash(settings.ADMIN_DEFAULT_PASSWORD)
+                admin.email = settings.OWNER_EMAIL
+                print(f'[seed] Admin {settings.ADMIN_DEFAULT_USERNAME!r} atualizado.')
+
+            result = await session.execute(
+                select(Tenant).where(Tenant.slug == settings.OWNER_TENANT_SLUG)
+            )
+            tenant = result.scalar_one_or_none()
+
+            if not tenant:
+                tenant = Tenant(
+                    nome=settings.OWNER_TENANT_NAME,
+                    slug=settings.OWNER_TENANT_SLUG,
+                    email_gestor=settings.OWNER_EMAIL,
+                    status=TenantStatus.active,
+                )
                 session.add(tenant)
                 await session.flush()
+                print(f'[seed] Tenant {settings.OWNER_TENANT_SLUG!r} criado.')
 
-                user = Usuario(
-                    username=username,
-                    email=f'{username}@app.com',
-                    password=get_password_hash(password),
-                    nome='Administrador',
-                    ativo=True,
-                    role=UsuarioRole.OWNER,
+            result = await session.execute(
+                select(User).where(User.email == settings.OWNER_EMAIL)
+            )
+            user = result.scalar_one_or_none()
+
+            if not user:
+                session.add(User(
+                    email=settings.OWNER_EMAIL,
+                    password=get_password_hash(settings.OWNER_PASSWORD),
+                    nome='Dono do Laboratório',
+                    role=UserRole.admin,
                     tenant_id=tenant.id,
-                )
-                session.add(user)
-                await session.flush()
-                print(f'[entrypoint] Usuário {username!r} criado (tenant_id={tenant.id}).')
-
-    # Seed admin global (sys-mgmt)
-    async with SessionLocal() as session:
-        async with session.begin():
-            result = await session.execute(select(Admin).where(Admin.username == username))
-            existing_admin = result.scalar_one_or_none()
-            if existing_admin:
-                print('[entrypoint] Admin ' + repr(username) + ' já existe, pulando seed de admin.')
+                    is_active=True,
+                ))
+                print(f'[seed] Usuário {settings.OWNER_EMAIL!r} criado.')
             else:
-                admin = Admin(
-                    username=username,
-                    email=username + '@app.com',
-                    password=get_password_hash(password),
-                    nome='Administrador',
-                    ativo=True,
-                )
-                session.add(admin)
-                await session.flush()
-                print('[entrypoint] Admin ' + repr(username) + ' criado.')
-
-    # Seed agentes padrão — upsert por nome para cada tenant
-    # Garante que novos agentes adicionados ao catálogo cheguem a todos os tenants existentes
-    async with SessionLocal() as session:
-        async with session.begin():
-            tenant_result = await session.execute(select(Tenant).order_by(Tenant.id))
-            for tenant in tenant_result.scalars().all():
-                nomes_result = await session.execute(
-                    select(Agente.nome).where(Agente.tenant_id == tenant.id)
-                )
-                nomes_existentes = {row[0] for row in nomes_result.all()}
-                criados = 0
-                for dados in AGENTES_PADRAO:
-                    if dados['nome'] not in nomes_existentes:
-                        session.add(Agente(**dados, tenant_id=tenant.id))
-                        criados += 1
-                if criados:
-                    print('[entrypoint] ' + str(criados) + ' agente(s) padrão adicionado(s) ao tenant_id=' + str(tenant.id))
-
-    # Seed system config — garante que llm_mode existe com padrão 'local'
-    async with SessionLocal() as session:
-        async with session.begin():
-            result = await session.execute(select(SystemConfig).where(SystemConfig.key == 'llm_mode'))
-            if not result.scalar_one_or_none():
-                session.add(SystemConfig(key='llm_mode', value='local'))
-                print('[entrypoint] SystemConfig llm_mode=local criado.')
-
-    # Seed servidores MCP — upsert por nome (adiciona novos, não sobrescreve existentes)
-    servidores_exemplo = [
-        dict(
-            nome='Fetch',
-            descricao='Busca e converte o conteúdo de qualquer URL para texto. Requer uvx (uv).',
-            command='uvx',
-            args=['mcp-server-fetch'],
-            env={},
-        ),
-        dict(
-            nome='Memory',
-            descricao='Grafo de conhecimento persistente: o agente pode salvar e recuperar fatos entre conversas. Requer Node.js.',
-            command='npx',
-            args=['-y', '@modelcontextprotocol/server-memory'],
-            env={},
-        ),
-        dict(
-            nome='Time',
-            descricao='Fornece data/hora atual e conversão de fusos horários. Requer Node.js.',
-            command='npx',
-            args=['-y', '@modelcontextprotocol/server-time'],
-            env={},
-        ),
-        dict(
-            nome='Puppeteer',
-            descricao='Automação de browser real: navega páginas, clica, extrai conteúdo e tira screenshots. Requer Node.js e Chromium.',
-            command='npx',
-            args=['-y', '@modelcontextprotocol/server-puppeteer'],
-            env={},
-        ),
-        dict(
-            nome='Clima (Open-Meteo)',
-            descricao='Previsão do tempo em tempo real para qualquer cidade. Gratuito, sem chave de API. Dados atualizados a cada hora.',
-            command='uv',
-            args=['run', 'python', '/app/mcp_servers/weather.py'],
-            env={},
-        ),
-    ]
-    async with SessionLocal() as session:
-        async with session.begin():
-            for dados in servidores_exemplo:
-                existe = await session.execute(
-                    select(McpServer).where(McpServer.nome == dados['nome'])
-                )
-                if not existe.scalar_one_or_none():
-                    session.add(McpServer(**dados, ativo=False))
-                    print('[entrypoint] Servidor MCP criado: ' + dados['nome'])
+                user.password = get_password_hash(settings.OWNER_PASSWORD)
+                user.tenant_id = tenant.id
+                user.is_active = True
+                print(f'[seed] Usuário {settings.OWNER_EMAIL!r} atualizado.')
 
 asyncio.run(main())
 "
+echo "[entrypoint] Seed concluído."
 
-echo "[entrypoint] Pronto. Iniciando servidor..."
+echo "[entrypoint] Iniciando servidor..."
 exec "$@"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,153 @@
+networks:
+  proxy:      # Traefik + serviços expostos via HTTPS
+    driver: bridge
+  internal:   # Banco, Redis, workers — sem exposição externa
+    driver: bridge
+
+volumes:
+  postgres_data:
+  minio_data:
+  traefik_certs:
+
+services:
+
+  # ── Traefik ───────────────────────────────────────────────────────────────────
+  traefik:
+    image: traefik:v3.1
+    restart: unless-stopped
+    networks:
+      - proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik_certs:/letsencrypt
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=proxy
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+      - --certificatesresolvers.letsencrypt.acme.httpchallenge=true
+      - --certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web
+      - --certificatesresolvers.letsencrypt.acme.email=admin@z3ndocs.uk
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
+      - --log.level=INFO
+
+  # ── API ───────────────────────────────────────────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: compose/prod/api/Dockerfile
+    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 2
+    env_file: .env.prod
+    networks:
+      - proxy
+      - internal
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.api.rule=Host(`api.z3ndocs.uk`)
+      - traefik.http.routers.api.entrypoints=websecure
+      - traefik.http.routers.api.tls.certresolver=letsencrypt
+      - traefik.http.services.api.loadbalancer.server.port=8000
+
+  # ── Celery Worker ─────────────────────────────────────────────────────────────
+  celery-worker:
+    build:
+      context: .
+      dockerfile: compose/prod/api/Dockerfile
+    command: uv run celery -A app.core.celery worker --loglevel=info --concurrency=2
+    env_file: .env.prod
+    networks:
+      - internal
+    depends_on:
+      - redis
+      - postgres
+    restart: unless-stopped
+
+  # ── Celery Beat ───────────────────────────────────────────────────────────────
+  celery-beat:
+    build:
+      context: .
+      dockerfile: compose/prod/api/Dockerfile
+    command: uv run celery -A app.core.celery beat --loglevel=info
+    env_file: .env.prod
+    networks:
+      - internal
+    depends_on:
+      - redis
+    restart: unless-stopped
+
+  # ── Celery Flower (dashboard protegido) ───────────────────────────────────────
+  celery-flower:
+    image: mher/flower:2.0
+    environment:
+      CELERY_BROKER_URL: redis://redis:6379/0
+    networks:
+      - proxy
+      - internal
+    depends_on:
+      - redis
+    restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.flower.rule=Host(`flower.z3ndocs.uk`)
+      - traefik.http.routers.flower.entrypoints=websecure
+      - traefik.http.routers.flower.tls.certresolver=letsencrypt
+      - traefik.http.routers.flower.middlewares=flower-auth
+      - traefik.http.services.flower.loadbalancer.server.port=5555
+      # Gerar senha: echo $(htpasswd -nb admin SUA_SENHA) | sed 's/\$/\$\$/g'
+      - "traefik.http.middlewares.flower-auth.basicauth.users=${FLOWER_BASICAUTH}"
+
+  # ── PostgreSQL ────────────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  # ── Redis ─────────────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    command: redis-server --save "" --appendonly no
+    networks:
+      - internal
+    restart: unless-stopped
+
+  # ── MinIO ─────────────────────────────────────────────────────────────────────
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+    volumes:
+      - minio_data:/data
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,7 @@
 |------|------|---------|----------|---------|
 | **F0** | Infraestrutura | — | `feature/f0-infra-docker` | Ambiente local completo |
 | **F1** | Fundação & Auth | M01 | `feature/f1-*` | Multi-tenancy, auth, roles |
+| **F1.5** | Outbox Genérico | — | `feature/f1-outbox-dispatcher` | Dispatcher extensível + handler registry |
 | **F2** | Core Metrológico | M02, M03, M04 | `feature/f2-*` | Padrões, instrumentos, calibração + GUM |
 | **F3** | Certificados | M05 | `feature/f3-*` | Emissão PDF ISO 17025 |
 | **F4** | Operação Comercial | M06, M07, M27 | `feature/f4-*` | Orçamentos, pedidos, estoque |
@@ -132,6 +133,161 @@ app/domains/
 - JWT payload: `{ tenant_id, user_id, role, exp }`
 - Refresh token com validade 7 dias armazenado em tabela `refresh_tokens`
 - Convite por e-mail via Celery task (não bloqueia a request) + Mailpit em dev
+
+---
+
+## F1.5 · Outbox Genérico — Dispatcher Extensível
+
+**Branch:** `feature/f1-outbox-dispatcher`
+
+### Objetivo
+
+Transformar o outbox de um despachante de e-mails hard-coded em uma **infraestrutura de entrega garantida para qualquer tarefa assíncrona**. A partir desta fase, adicionar um novo tipo de processamento assíncrono (emissão de certificado, análise GUM, geração de PDF, webhook externo) é apenas registrar um handler — sem tocar no worker ou no modelo do outbox.
+
+### Motivação
+
+O worker atual (`celery.py`) contém um `if/elif` que cresce a cada novo tipo de evento e mistura a lógica de entrega com a lógica de negócio. A fase F3 (Certificados) e F5 (Alertas) precisarão despachar Celery tasks pesadas com garantia de at-least-once delivery — o outbox é o lugar certo para isso, mas precisa ser genérico primeiro.
+
+### Estrutura após a refatoração
+
+```
+app/domains/outbox/
+├── model.py           # OutboxEvent, OutboxStatus, OutboxEventType (enum cresce aqui)
+├── repository.py      # sem mudança
+├── dispatcher.py      # NOVO — handler registry + dispatch()
+└── handlers/
+    ├── __init__.py    # importa todos os módulos para forçar registro
+    ├── auth.py        # USER_INVITE, PASSWORD_RESET → e-mail
+    ├── certificates.py  # CERTIFICATE_EMIT → generate_certificate.apply_async()
+    └── alerts.py      # STANDARD_EXPIRY_ALERT, INSTRUMENT_EXPIRY_ALERT → e-mail/task
+```
+
+### Contrato do handler
+
+```python
+# app/domains/outbox/dispatcher.py
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+from app.domains.outbox.model import OutboxEvent, OutboxEventType
+
+Handler: TypeAlias = Callable[[OutboxEvent], Awaitable[None]]
+
+_registry: dict[OutboxEventType, Handler] = {}
+
+def register(event_type: OutboxEventType) -> Callable[[Handler], Handler]:
+    def decorator(fn: Handler) -> Handler:
+        _registry[event_type] = fn
+        return fn
+    return decorator
+
+async def dispatch(event: OutboxEvent) -> None:
+    handler = _registry.get(event.event_type)
+    if handler is None:
+        raise ValueError(f"Nenhum handler registrado para {event.event_type}")
+    await handler(event)
+```
+
+### Handlers de auth (migração do código atual)
+
+```python
+# app/domains/outbox/handlers/auth.py
+import asyncio
+from app.core.email import email_service
+from app.domains.outbox.dispatcher import register
+from app.domains.outbox.model import OutboxEventType
+
+@register(OutboxEventType.USER_INVITE)
+async def handle_user_invite(event) -> None:
+    await asyncio.to_thread(
+        email_service.send_user_invite,
+        email=event.payload["email"],
+        nome=event.payload["nome"],
+        token=event.payload["token"],
+    )
+
+@register(OutboxEventType.PASSWORD_RESET)
+async def handle_password_reset(event) -> None:
+    await asyncio.to_thread(
+        email_service.send_password_reset,
+        email=event.payload["email"],
+        token=event.payload["token"],
+    )
+```
+
+### Handler de Celery task (padrão para F3+)
+
+```python
+# app/domains/outbox/handlers/certificates.py
+from app.domains.outbox.dispatcher import register
+from app.domains.outbox.model import OutboxEventType
+
+@register(OutboxEventType.CERTIFICATE_EMIT)
+async def handle_certificate_emit(event) -> None:
+    from app.domains.certificates.tasks import generate_certificate_pdf
+    # idempotency_key vira task_id — Celery ignora reenvios do mesmo ID
+    generate_certificate_pdf.apply_async(
+        kwargs=event.payload,
+        task_id=str(event.idempotency_key),
+    )
+```
+
+### Worker genérico (substitui o if/elif atual)
+
+```python
+# app/core/celery.py — _run_process_outbox()
+async def _run_process_outbox():
+    import app.domains.outbox.handlers  # garante que os handlers estejam registrados
+
+    from app.domains.outbox.dispatcher import dispatch
+
+    events = await repo.get_pending(limit=10)
+    for event in events:
+        try:
+            await dispatch(event)
+            await repo.mark_processed(event.id)
+            await session.commit()
+        except Exception as exc:
+            await session.rollback()
+            await repo.mark_failed(event.id, str(exc))
+            await session.commit()
+```
+
+### Como adicionar um novo tipo de evento (F3 em diante)
+
+1. Adicionar o valor em `OutboxEventType` no `model.py`
+2. Criar (ou adicionar em) um arquivo em `handlers/`
+3. Decorar a função com `@register(OutboxEventType.NOVO_TIPO)`
+4. Importar o módulo no `handlers/__init__.py`
+
+O worker **não precisa de nenhuma alteração**.
+
+### Tipos de evento planejados
+
+| Tipo | Handler | Usado em |
+|------|---------|----------|
+| `USER_INVITE` | e-mail | F1 |
+| `PASSWORD_RESET` | e-mail | F1 |
+| `CERTIFICATE_EMIT` | Celery task `generate_certificate_pdf` | F3 |
+| `CERTIFICATE_REVOKE` | Celery task `revoke_certificate_pdf` + e-mail | F3 |
+| `STANDARD_EXPIRY_ALERT` | e-mail ao responsável do laboratório | F5 |
+| `INSTRUMENT_EXPIRY_ALERT` | e-mail ao cliente | F5 |
+| `QUOTATION_SENT` | e-mail ao cliente com PDF | F4 |
+
+### Garantias
+
+- **At-least-once delivery:** o evento só é marcado `PROCESSED` após o handler retornar sem exceção.
+- **Idempotência em Celery tasks:** `task_id=str(event.idempotency_key)` garante que reenvios do mesmo evento não criem execuções duplicadas.
+- **Skip_locked:** o `SELECT ... FOR UPDATE SKIP LOCKED` no repositório garante que múltiplos workers não processem o mesmo evento simultaneamente.
+- **Max attempts:** após `max_attempts` falhas consecutivas o evento vai para `FAILED` e para de ser reprocessado automaticamente.
+
+### Entregáveis F1.5
+
+- `app/domains/outbox/dispatcher.py` — registry + `dispatch()`
+- `app/domains/outbox/handlers/__init__.py` — ponto de importação centralizado
+- `app/domains/outbox/handlers/auth.py` — migração do código atual
+- `app/core/celery.py` — worker genérico (remove o `if/elif`)
+- Testes unitários do dispatcher (mock dos handlers)
+- Teste de integração: evento desconhecido levanta `ValueError`
 
 ---
 
@@ -527,6 +683,11 @@ f1-tenant-provisioning
       └── f1-user-management depende de f1-auth-jwt
           └── f1-rbac depende de f1-auth-jwt
 
+f1-outbox-dispatcher
+  └── depende de f1-user-management (migra handlers existentes)
+  └── f3-certificate-emission depende de f1-outbox-dispatcher
+  └── f5-standard-alerts depende de f1-outbox-dispatcher
+
 f2-standards
   └── f2-calibration-core depende de f2-standards + f2-clients-instruments
 
@@ -562,6 +723,7 @@ f8-excel-base-workbook
 |------|----------|--------------------|---------------|
 | F0 | 1 | — | — |
 | F1 | 4 | H01–H04 | S01, S02, S40 |
+| F1.5 | 1 | — (infra transversal) | — |
 | F2 | 4 | H05–H14 | S05–S09, S19–S21, S26–S31 |
 | F3 | 2 | H15–H16 | Aba Certificado no S06 |
 | F4 | 6 | H17–H23, H78–H87 | S10–S18, S24–S25 |
@@ -569,4 +731,4 @@ f8-excel-base-workbook
 | F6 | 3 | H30–H33 | S41–S45 |
 | F7 | 3 | H34–H37 | S46–S48 |
 | F8 | 5 | H88–H93 | Aba Planilha no S06 |
-| **Total** | **32** | **~60 histórias** | **~48 telas** |
+| **Total** | **33** | **~60 histórias** | **~48 telas** |

--- a/docs/f1.5-outbox-dispatcher.md
+++ b/docs/f1.5-outbox-dispatcher.md
@@ -1,0 +1,215 @@
+# F1.5 · Outbox Genérico — Dispatcher Extensível
+
+## Problema
+
+O worker Celery original (`app/core/celery.py`) acumulava toda a lógica de despacho num único bloco `if/elif`:
+
+```python
+# antes — crescia a cada novo tipo de evento
+if event.event_type == OutboxEventType.USER_INVITE:
+    email_service.send_user_invite(...)
+elif event.event_type == OutboxEventType.PASSWORD_RESET:
+    ...
+```
+
+Isso criava dois problemas:
+- **Acoplamento:** o worker precisava conhecer e importar a lógica de negócio de cada domínio.
+- **Crescimento inevitável:** cada novo tipo de evento (certificado, alerta, PDF) exigia alterar o worker — risco de regressão e conflito entre branches.
+
+---
+
+## Solução — Handler Registry
+
+Separar o **outbox como store de entrega garantida** do **o que fazer com cada evento**.
+
+O worker vira um dispatcher genérico. Quem sabe processar cada tipo é um handler registrado por decorador — o mesmo padrão de roteamento de frameworks como FastAPI e Flask.
+
+---
+
+## Arquitetura
+
+```
+app/domains/outbox/
+├── model.py           # OutboxEvent, OutboxStatus, OutboxEventType
+├── repository.py      # get_pending, mark_processed, mark_failed
+├── dispatcher.py      # registry + register() + dispatch()    ← NOVO
+└── handlers/
+    ├── __init__.py    # importa todos os módulos → força registro ← NOVO
+    └── auth.py        # USER_INVITE                            ← NOVO
+```
+
+---
+
+## dispatcher.py
+
+```python
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+from app.domains.outbox.model import OutboxEvent, OutboxEventType
+
+Handler: TypeAlias = Callable[[OutboxEvent], Awaitable[None]]
+
+_registry: dict[OutboxEventType, Handler] = {}
+
+def register(event_type: OutboxEventType) -> Callable[[Handler], Handler]:
+    def decorator(fn: Handler) -> Handler:
+        _registry[event_type] = fn
+        return fn
+    return decorator
+
+async def dispatch(event: OutboxEvent) -> None:
+    handler = _registry.get(event.event_type)
+    if handler is None:
+        raise ValueError(f"Nenhum handler registrado para {event.event_type!r}")
+    await handler(event)
+```
+
+`_registry` é um dicionário module-level: vive durante toda a vida do processo e é populado na importação dos módulos de handler.
+
+---
+
+## handlers/auth.py
+
+```python
+import asyncio
+from app.core.email import email_service
+from app.domains.outbox.dispatcher import register
+from app.domains.outbox.model import OutboxEvent, OutboxEventType
+
+@register(OutboxEventType.USER_INVITE)
+async def handle_user_invite(event: OutboxEvent) -> None:
+    await asyncio.to_thread(
+        email_service.send_user_invite,
+        email=event.payload["email"],
+        nome=event.payload["nome"],
+        token=event.payload["token"],
+    )
+```
+
+`asyncio.to_thread` é necessário porque `email_service.send_user_invite` é síncrono (SMTP bloqueante). Sem isso o event loop travaria durante o envio.
+
+---
+
+## handlers/\_\_init\_\_.py
+
+```python
+from app.domains.outbox.handlers import auth  # noqa: F401
+```
+
+A única responsabilidade deste arquivo é garantir que os módulos de handler sejam importados — e portanto os decoradores `@register` executados — antes que o worker chame `dispatch()`. Adicionar um novo domínio é incluir uma linha aqui.
+
+---
+
+## Worker genérico (celery.py)
+
+```python
+async def _run_process_outbox() -> str:
+    import app.domains.outbox.handlers  # garante registro de todos os handlers
+
+    from app.domains.outbox.dispatcher import dispatch
+    from app.domains.outbox.repository import OutboxRepository
+
+    # ... setup de engine e session ...
+
+    for event in events:
+        try:
+            await dispatch(event)
+            await repo.mark_processed(event.id)
+            await session.commit()
+        except Exception as exc:
+            await session.rollback()
+            await repo.mark_failed(event.id, str(exc))
+            await session.commit()
+```
+
+O worker não conhece nenhum domínio de negócio. A única decisão que toma é: processar → marcar como processado; falhar → incrementar tentativas.
+
+---
+
+## Como adicionar um novo tipo de evento
+
+**1. Adicionar o valor no enum** (`model.py`):
+```python
+class OutboxEventType(enum.StrEnum):
+    USER_INVITE    = "user_invite"
+    PASSWORD_RESET = "password_reset"
+    CERTIFICATE_EMIT = "certificate_emit"   # ← novo
+```
+
+**2. Criar o handler** (`handlers/certificates.py`):
+```python
+from app.domains.outbox.dispatcher import register
+from app.domains.outbox.model import OutboxEvent, OutboxEventType
+
+@register(OutboxEventType.CERTIFICATE_EMIT)
+async def handle_certificate_emit(event: OutboxEvent) -> None:
+    from app.domains.certificates.tasks import generate_certificate_pdf
+    generate_certificate_pdf.apply_async(
+        kwargs=event.payload,
+        task_id=str(event.idempotency_key),  # idempotência end-to-end
+    )
+```
+
+**3. Importar no `__init__.py`**:
+```python
+from app.domains.outbox.handlers import auth, certificates  # noqa: F401
+```
+
+O worker não precisa de nenhuma alteração.
+
+---
+
+## Idempotência com Celery tasks
+
+Quando o handler despacha uma Celery task pesada (PDF, análise), passa o `idempotency_key` do outbox como `task_id`:
+
+```python
+generate_certificate_pdf.apply_async(
+    kwargs=event.payload,
+    task_id=str(event.idempotency_key),
+)
+```
+
+O Celery ignora chamadas `.apply_async` com um `task_id` já existente no backend. Combinado com o `SELECT ... FOR UPDATE SKIP LOCKED` do repositório, isso garante que mesmo em caso de retry do outbox a task não é executada duas vezes.
+
+---
+
+## Garantias do padrão
+
+| Garantia | Mecanismo |
+|----------|-----------|
+| At-least-once delivery | Evento só vai para `PROCESSED` após handler retornar sem exceção |
+| Sem duplicação entre workers | `SELECT ... FOR UPDATE SKIP LOCKED` no `get_pending` |
+| Sem duplicação em Celery tasks | `task_id = str(event.idempotency_key)` |
+| Retry automático | `attempts < max_attempts` antes de marcar `FAILED` |
+| Rastreabilidade de falhas | `error_message` salvo no banco a cada tentativa |
+
+---
+
+## Testes
+
+**`tests/test_outbox_dispatcher.py`** — 5 testes unitários, sem banco, sem Docker.
+
+| Teste | O que verifica |
+|-------|----------------|
+| `test_dispatch_chama_handler_registrado` | `dispatch()` invoca o handler correto |
+| `test_dispatch_levanta_para_tipo_sem_handler` | `ValueError` para tipo não registrado |
+| `test_register_substitui_handler_existente` | segundo `@register` no mesmo tipo substitui o anterior |
+| `test_dispatch_handlers_independentes_por_tipo` | handlers de tipos distintos não interferem |
+| `test_handle_user_invite_chama_email_service` | handler de auth chama `email_service` com args corretos |
+
+O fixture `isolate_registry` salva e restaura o estado do `_registry` após cada teste, evitando contaminação entre eles.
+
+---
+
+## Tipos planejados para fases futuras
+
+| Tipo | Handler | Fase |
+|------|---------|------|
+| `USER_INVITE` | e-mail de convite | F1 ✅ |
+| `PASSWORD_RESET` | e-mail de redefinição | F1 (pendente handler) |
+| `CERTIFICATE_EMIT` | Celery task → PDF ISO 17025 | F3 |
+| `CERTIFICATE_REVOKE` | Celery task → PDF com marca d'água + e-mail | F3 |
+| `STANDARD_EXPIRY_ALERT` | e-mail ao responsável do laboratório | F5 |
+| `INSTRUMENT_EXPIRY_ALERT` | e-mail ao cliente | F5 |
+| `QUOTATION_SENT` | e-mail ao cliente com PDF do orçamento | F4 |


### PR DESCRIPTION
## Contexto

O worker Celery original acumulava toda a lógica de despacho num `if/elif` crescente, acoplando o core de infraestrutura com a lógica de negócio de cada domínio.

## O que muda

Substitui o bloco `if/elif` por um **handler registry**: cada tipo de evento tem um handler registrado por decorador. O worker vira um dispatcher genérico que nunca mais precisa ser alterado.

## Arquivos

| Arquivo | Papel |
|---------|-------|
| `outbox/dispatcher.py` | Registry + `@register()` + `dispatch()` |
| `outbox/handlers/auth.py` | Handler de `USER_INVITE` (migrado do worker) |
| `outbox/handlers/__init__.py` | Ponto único de importação para garantir registro |
| `core/celery.py` | Worker reduzido a `dispatch(event)` |
| `compose/dev/api/Dockerfile` | Corrigido para `uv sync --extra dev` (pytest no build) |
| `docs/f1.5-outbox-dispatcher.md` | Documentação detalhada da fase |

## Como adicionar um novo tipo de evento (F3+)

1. Adicionar valor em `OutboxEventType`
2. Criar handler em `handlers/<dominio>.py` com `@register(...)`
3. Importar o módulo em `handlers/__init__.py`

O worker não toca.

## Testes

5 testes unitários sem banco nem Docker:

- `test_dispatch_chama_handler_registrado`
- `test_dispatch_levanta_para_tipo_sem_handler`
- `test_register_substitui_handler_existente`
- `test_dispatch_handlers_independentes_por_tipo`
- `test_handle_user_invite_chama_email_service`

Suite completa: **25/25 passando**.

## Referência

Documentação completa: `docs/f1.5-outbox-dispatcher.md`