### PR TITLE
feat: Flutter Web na esteira de prod (12-factor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/compose/dev/frontend/Dockerfile
+++ b/compose/dev/frontend/Dockerfile
@@ -20,4 +20,4 @@ COPY frontend/apps/lab_app/ .
 # Expõe a porta
 EXPOSE 3000
 
-CMD ["flutter", "run", "-d", "web-server", "--web-port", "3000", "--web-hostname", "0.0.0.0"]
+CMD ["flutter", "run", "-d", "web-server", "--web-port", "3000", "--web-hostname", "0.0.0.0", "--dart-define=API_URL=http://localhost:8000"]

--- a/compose/prod/frontend/Dockerfile
+++ b/compose/prod/frontend/Dockerfile
@@ -1,18 +1,24 @@
-# Stage 1: build the Vue SPA
-FROM node:20-alpine AS builder
+# ── Stage 1: Flutter build ────────────────────────────────────────────────────
+FROM ghcr.io/cirruslabs/flutter:stable AS builder
+
+ARG API_URL=https://api.z3ndocs.uk
 
 WORKDIR /app
 
-COPY frontend/package.json frontend/package-lock.json ./
-RUN npm ci
+# Copia pacotes do monorepo antes para resolver path dependencies
+COPY frontend/packages/ frontend/packages/
+COPY frontend/apps/lab_app/ frontend/apps/lab_app/
 
-COPY frontend/ .
-RUN npm run build
+WORKDIR /app/frontend/apps/lab_app
 
-# Stage 2: serve with nginx
+RUN flutter pub get && \
+    flutter build web --release \
+        --dart-define=API_URL=$API_URL
+
+# ── Stage 2: Servir com nginx ─────────────────────────────────────────────────
 FROM nginx:alpine
 
-COPY --from=builder /app/dist /usr/share/nginx/html
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/frontend/apps/lab_app/build/web /usr/share/nginx/html
+COPY compose/prod/frontend/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/compose/prod/frontend/nginx.conf
+++ b/compose/prod/frontend/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml text/javascript application/wasm;
+
+    # Cache agressivo para assets com hash no nome
+    location ~* \.(js|css|wasm|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback — todas as rotas vão para index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,26 @@ volumes:
 
 services:
 
+  # ── Frontend (Flutter Web) ───────────────────────────────────────────────────
+  frontend:
+    build:
+      context: .
+      dockerfile: compose/prod/frontend/Dockerfile
+      args:
+        API_URL: https://api.z3ndocs.uk
+    networks:
+      - traefik_net
+    depends_on:
+      - api
+    restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.normatik-web.rule=Host(`z3ndocs.uk`)
+      - traefik.http.routers.normatik-web.entrypoints=websecure
+      - traefik.http.routers.normatik-web.tls.certresolver=letsencrypt
+      - traefik.http.services.normatik-web.loadbalancer.server.port=80
+      - traefik.docker.network=coracaodemae_traefik_network
+
   # ── API ───────────────────────────────────────────────────────────────────────
   api:
     build:

--- a/frontend/apps/lab_app/lib/core/api/client.dart
+++ b/frontend/apps/lab_app/lib/core/api/client.dart
@@ -1,0 +1,53 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import '../../features/auth/auth_provider.dart';
+
+// O provedor agora passa o 'ref' para o ApiClient
+final apiClientProvider = Provider((ref) => ApiClient(ref));
+
+class ApiClient {
+  final Ref _ref;
+  late Dio dio;
+  final storage = const FlutterSecureStorage();
+
+  ApiClient(this._ref) {
+    dio = Dio(
+      BaseOptions(
+        baseUrl: const String.fromEnvironment(
+          'API_URL',
+          defaultValue: 'http://localhost:8000',
+        ),
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 3),
+      ),
+    );
+
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          final token = await storage.read(key: 'access_token');
+          if (token != null) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
+          return handler.next(options);
+        },
+        onError: (DioException e, handler) {
+          // Se receber 401, dispara o logout automático
+          if (e.response?.statusCode == 401) {
+            _ref.read(authProvider.notifier).logout();
+          }
+          return handler.next(e);
+        },
+      ),
+    );
+  }
+
+  Future<Response> post(String path, {dynamic data}) async {
+    return await dio.post(path, data: data);
+  }
+
+  Future<void> logout() async {
+    await storage.delete(key: 'access_token');
+  }
+}

--- a/frontend/apps/lab_app/lib/core/theme/theme_provider.dart
+++ b/frontend/apps/lab_app/lib/core/theme/theme_provider.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final themeModeProvider = StateProvider<ThemeMode>((ref) => ThemeMode.light);

--- a/frontend/apps/lab_app/lib/features/auth/accept_invite_page.dart
+++ b/frontend/apps/lab_app/lib/features/auth/accept_invite_page.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:normatiq_ui/normatiq_ui.dart';
+import '../../core/api/client.dart';
+import 'auth_provider.dart';
+
+class AcceptInvitePage extends ConsumerStatefulWidget {
+  final String token;
+
+  const AcceptInvitePage({super.key, required this.token});
+
+  @override
+  ConsumerState<AcceptInvitePage> createState() => _AcceptInvitePageState();
+}
+
+class _AcceptInvitePageState extends ConsumerState<AcceptInvitePage> {
+  final _formKey = GlobalKey<FormState>();
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  bool _isLoading = false;
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  void _handleSetPassword() async {
+    if (_formKey.currentState!.validate()) {
+      setState(() => _isLoading = true);
+      try {
+        final dio = ref.read(apiClientProvider).dio;
+        await dio.post('/api/auth/accept-invite', data: {
+          'invite_token': widget.token,
+          'password': _passwordController.text,
+        });
+
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text("Senha definida com sucesso! Agora você pode entrar.")),
+          );
+          context.go('/login');
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text("Erro ao ativar conta. O link pode ter expirado."),
+              backgroundColor: NormatiqColors.danger700,
+            ),
+          );
+        }
+      } finally {
+        if (mounted) setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(NormatiqSpacing.s6),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(NormatiqSpacing.s8),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const NormatiqLogo(size: 32),
+                      const SizedBox(height: 32),
+                      const Text(
+                        "Ative sua conta",
+                        style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 8),
+                      const Text(
+                        "Defina sua senha inicial para acessar o laboratório.",
+                        style: TextStyle(color: NormatiqColors.neutral500),
+                      ),
+                      const SizedBox(height: 32),
+                      Form(
+                        key: _formKey,
+                        child: Column(
+                          children: [
+                            TextFormField(
+                              controller: _passwordController,
+                              decoration: InputDecoration(
+                                labelText: "Nova Senha",
+                                prefixIcon: const Icon(Icons.lock_outline),
+                                suffixIcon: IconButton(
+                                  icon: Icon(_obscurePassword ? Icons.visibility_off_outlined : Icons.visibility_outlined),
+                                  onPressed: () => setState(() => _obscurePassword = !_obscurePassword),
+                                ),
+                              ),
+                              obscureText: _obscurePassword,
+                              validator: (v) => v!.length < 6 ? "A senha deve ter pelo menos 6 caracteres" : null,
+                            ),
+                            const SizedBox(height: 16),
+                            TextFormField(
+                              controller: _confirmController,
+                              decoration: const InputDecoration(
+                                labelText: "Confirmar Senha",
+                                prefixIcon: Icon(Icons.lock_reset_outlined),
+                              ),
+                              obscureText: _obscurePassword,
+                              validator: (v) => v != _passwordController.text ? "As senhas não conferem" : null,
+                            ),
+                            const SizedBox(height: 32),
+                            ElevatedButton(
+                              onPressed: _isLoading ? null : _handleSetPassword,
+                              child: _isLoading 
+                                ? const SizedBox(height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                                : const Text("Ativar Conta e Entrar"),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/apps/lab_app/lib/features/auth/auth_provider.dart
+++ b/frontend/apps/lab_app/lib/features/auth/auth_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import '../../core/api/client.dart';
+import 'package:dio/dio.dart';
+
+enum AuthStatus { idle, loading, authenticated, unauthenticated, error }
+
+class AuthState {
+  final AuthStatus status;
+  final String? errorMessage;
+
+  AuthState({required this.status, this.errorMessage});
+}
+
+class AuthNotifier extends StateNotifier<AuthState> {
+  final Ref _ref;
+  final _storage = const FlutterSecureStorage();
+
+  AuthNotifier(this._ref) : super(AuthState(status: AuthStatus.idle)) {
+    checkAuth();
+  }
+
+  Future<void> checkAuth() async {
+    final token = await _storage.read(key: 'access_token');
+    if (token != null) {
+      state = AuthState(status: AuthStatus.authenticated);
+    } else {
+      state = AuthState(status: AuthStatus.unauthenticated);
+    }
+  }
+
+  Future<void> login(String email, String password) async {
+    state = AuthState(status: AuthStatus.loading);
+
+    try {
+      final formData = FormData.fromMap({
+        'username': email,
+        'password': password,
+      });
+
+      // Acessamos o Dio via ref para evitar circularidade no construtor
+      final dio = _ref.read(apiClientProvider).dio;
+      final response = await dio.post('/api/auth/login', data: formData);
+      
+      final token = response.data['access_token'];
+      await _storage.write(key: 'access_token', value: token);
+
+      state = AuthState(status: AuthStatus.authenticated);
+    } on DioException catch (e) {
+      final message = e.response?.data['detail'] ?? 'Erro ao realizar login';
+      state = AuthState(status: AuthStatus.error, errorMessage: message);
+    } catch (e) {
+      state = AuthState(status: AuthStatus.error, errorMessage: 'Erro inesperado');
+    }
+  }
+
+  Future<void> logout() async {
+    await _storage.delete(key: 'access_token');
+    state = AuthState(status: AuthStatus.unauthenticated);
+  }
+}
+
+final authProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
+  return AuthNotifier(ref);
+});

--- a/frontend/apps/lab_app/lib/features/auth/login_page.dart
+++ b/frontend/apps/lab_app/lib/features/auth/login_page.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:normatiq_ui/normatiq_ui.dart';
+import 'auth_provider.dart';
+
+class LoginPage extends ConsumerStatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  ConsumerState<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends ConsumerState<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _handleLogin() async {
+    if (_formKey.currentState!.validate()) {
+      await ref.read(authProvider.notifier).login(
+        _emailController.text,
+        _passwordController.text,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(authProvider, (previous, next) {
+      if (next.status == AuthStatus.authenticated) {
+        context.go('/');
+      } else if (next.status == AuthStatus.error) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(next.errorMessage ?? 'Erro no login'),
+            backgroundColor: NormatiqColors.danger700,
+          ),
+        );
+      }
+    });
+
+    final authState = ref.watch(authProvider);
+    final isLoading = authState.status == AuthStatus.loading;
+
+    return Scaffold(
+      backgroundColor: NormatiqColors.neutral50,
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(NormatiqSpacing.s6),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: Card(
+                elevation: 0,
+                color: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(NormatiqRadius.lg),
+                  side: const BorderSide(color: NormatiqColors.neutral200),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(NormatiqSpacing.s6),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const SizedBox(height: 24),
+                      const Center(
+                        child: NormatiqLogo(size: 40),
+                      ),
+                      const SizedBox(height: 32),
+                      Form(
+                        key: _formKey,
+                        child: Column(
+                          children: [
+                            TextFormField(
+                              controller: _emailController,
+                              decoration: const InputDecoration(
+                                labelText: "E-mail",
+                                prefixIcon: Icon(Icons.email_outlined),
+                              ),
+                              keyboardType: TextInputType.emailAddress,
+                              enabled: !isLoading,
+                              validator: (v) => v!.isEmpty ? "Informe o e-mail" : null,
+                            ),
+                            const SizedBox(height: 24),
+                            TextFormField(
+                              controller: _passwordController,
+                              decoration: InputDecoration(
+                                labelText: "Senha",
+                                prefixIcon: const Icon(Icons.lock_outline),
+                                suffixIcon: IconButton(
+                                  icon: Icon(_obscurePassword
+                                      ? Icons.visibility_off_outlined
+                                      : Icons.visibility_outlined),
+                                  onPressed: () =>
+                                      setState(() => _obscurePassword = !_obscurePassword),
+                                ),
+                              ),
+                              obscureText: _obscurePassword,
+                              enabled: !isLoading,
+                              validator: (v) => v!.isEmpty ? "Informe a senha" : null,
+                            ),
+                            const SizedBox(height: 32),
+                            ElevatedButton(
+                              onPressed: isLoading ? null : _handleLogin,
+                              child: isLoading
+                                  ? const SizedBox(
+                                      height: 20,
+                                      width: 20,
+                                      child: CircularProgressIndicator(
+                                          strokeWidth: 2, color: Colors.white))
+                                  : const Text("Entrar"),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      const Center(
+                        child: Text(
+                          "v1.0.0",
+                          style: TextStyle(color: NormatiqColors.neutral400, fontSize: 12),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/apps/lab_app/lib/features/home/dashboard_page.dart
+++ b/frontend/apps/lab_app/lib/features/home/dashboard_page.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:normatiq_ui/normatiq_ui.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      appBar: AppBar(
+        title: const Text("Dashboard", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+        backgroundColor: theme.colorScheme.surface,
+        surfaceTintColor: Colors.transparent,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              "Laboratório Normatiq Demo · Abril 2026",
+              style: TextStyle(color: theme.colorScheme.onSurface.withOpacity(0.5), fontSize: 13),
+            ),
+            const SizedBox(height: 24),
+            
+            // Stats Grid
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final crossAxisCount = constraints.maxWidth > 1200 ? 4 : (constraints.maxWidth > 600 ? 2 : 1);
+                return GridView.count(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  crossAxisCount: crossAxisCount,
+                  crossAxisSpacing: 16,
+                  mainAxisSpacing: 16,
+                  childAspectRatio: 2.2,
+                  children: const [
+                    NormatiqStatCard(value: "47", label: "Calibrações este mês", sub: "↑ 12 vs. março"),
+                    NormatiqStatCard(value: "38", label: "Certificados emitidos", sub: "mês atual", color: Color(0xFF00B5A4)),
+                    NormatiqStatCard(value: "1", label: "Padrão vencido", sub: "ação necessária", color: NormatiqColors.danger700),
+                    NormatiqStatCard(value: "5", label: "Em rascunho", sub: "aguardando conclusão", color: Color(0xFFD97706)),
+                  ],
+                );
+              },
+            ),
+            
+            const SizedBox(height: 32),
+            
+            // Columns
+            if (MediaQuery.of(context).size.width > 900)
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(flex: 1, child: _buildAlertsSection(context)),
+                  const SizedBox(width: 24),
+                  Expanded(flex: 2, child: _buildRecentSection(context)),
+                ],
+              )
+            else ...[
+              _buildAlertsSection(context),
+              const SizedBox(height: 24),
+              _buildRecentSection(context),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Text(
+        title.toUpperCase(),
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          color: Theme.of(context).colorScheme.onSurface.withOpacity(0.4),
+          letterSpacing: 1,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlertsSection(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSectionTitle(context, "Alertas ativos"),
+        Card(
+          margin: EdgeInsets.zero,
+          child: Column(
+            children: [
+              _buildAlertItem(context, "PAT-003 — Termômetro de referência vencido há 40 dias", true),
+              _buildAlertItem(context, "PAT-002 — Bloco padrão grau 1 vence em 17 dias", false),
+              _buildAlertItem(context, "5 calibrações em rascunho aguardando conclusão", false, isLast: true),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAlertItem(BuildContext context, String label, bool isDanger, {bool isLast = false}) {
+    final color = isDanger ? NormatiqColors.danger700 : const Color(0xFFD97706);
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      decoration: BoxDecoration(
+        border: Border(
+          left: BorderSide(color: color, width: 3),
+          bottom: isLast ? BorderSide.none : BorderSide(color: Theme.of(context).dividerColor),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.warning_amber_rounded, size: 16, color: color),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              label, 
+              style: TextStyle(fontSize: 13, color: Theme.of(context).colorScheme.onSurface.withOpacity(0.8))
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRecentSection(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSectionTitle(context, "Calibrações recentes"),
+        const Card(
+          margin: EdgeInsets.zero,
+          child: Center(
+            child: Padding(
+              padding: EdgeInsets.all(40),
+              child: Text("Tabela de calibrações em breve..."),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/apps/lab_app/lib/features/home/main_shell.dart
+++ b/frontend/apps/lab_app/lib/features/home/main_shell.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:normatiq_ui/normatiq_ui.dart';
+import '../auth/auth_provider.dart';
+import '../../core/theme/theme_provider.dart';
+
+class MainShell extends ConsumerWidget {
+  final StatefulNavigationShell navigationShell;
+
+  const MainShell({
+    super.key,
+    required this.navigationShell,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isWide = MediaQuery.of(context).size.width >= 600;
+    final themeMode = ref.watch(themeModeProvider);
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: Row(
+        children: [
+          if (isWide)
+            Container(
+              width: MediaQuery.of(context).size.width >= 900 ? 220 : 80,
+              color: NormatiqColors.primary600,
+              child: Column(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+                    child: NormatiqLogo(size: 28, isDark: true),
+                  ),
+                  const Divider(color: Colors.white10, height: 1),
+                  Expanded(
+                    child: NavigationRail(
+                      extended: MediaQuery.of(context).size.width >= 900,
+                      backgroundColor: Colors.transparent,
+                      unselectedIconTheme: const IconThemeData(color: Colors.white60),
+                      selectedIconTheme: const IconThemeData(color: NormatiqColors.accent100),
+                      unselectedLabelTextStyle: const TextStyle(color: Colors.white60),
+                      selectedLabelTextStyle: const TextStyle(color: Colors.white),
+                      indicatorColor: Colors.white12,
+                      destinations: const [
+                        NavigationRailDestination(
+                          icon: Icon(Icons.grid_view_outlined),
+                          selectedIcon: Icon(Icons.grid_view),
+                          label: Text('Dashboard'),
+                        ),
+                        NavigationRailDestination(
+                          icon: Icon(Icons.straighten_outlined),
+                          selectedIcon: Icon(Icons.straighten),
+                          label: Text('Calibrações'),
+                        ),
+                        NavigationRailDestination(
+                          icon: Icon(Icons.science_outlined),
+                          selectedIcon: Icon(Icons.science),
+                          label: Text('Padrões'),
+                        ),
+                        NavigationRailDestination(
+                          icon: Icon(Icons.people_outline),
+                          selectedIcon: Icon(Icons.people),
+                          label: Text('Clientes'),
+                        ),
+                        NavigationRailDestination(
+                          icon: Icon(Icons.group_outlined),
+                          selectedIcon: Icon(Icons.group),
+                          label: Text('Usuários'),
+                        ),
+                      ],
+                      selectedIndex: navigationShell.currentIndex,
+                      onDestinationSelected: (index) => navigationShell.goBranch(index),
+                    ),
+                  ),
+                  
+                  const Divider(color: Colors.white10, height: 1),
+                  
+                  // Botões de Sistema
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+                    child: Column(
+                      children: [
+                        ListTile(
+                          visualDensity: VisualDensity.compact,
+                          leading: Icon(
+                            themeMode == ThemeMode.light ? Icons.dark_mode_outlined : Icons.light_mode_outlined,
+                            color: Colors.white70,
+                            size: 20,
+                          ),
+                          title: MediaQuery.of(context).size.width >= 900 
+                            ? Text(themeMode == ThemeMode.light ? "Tema Escuro" : "Tema Claro", 
+                                style: const TextStyle(color: Colors.white70, fontSize: 13)) 
+                            : null,
+                          onTap: () {
+                            ref.read(themeModeProvider.notifier).state = 
+                              themeMode == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
+                          },
+                        ),
+                        ListTile(
+                          visualDensity: VisualDensity.compact,
+                          leading: const Icon(Icons.logout_outlined, color: Color(0xFFFDA4AF), size: 20),
+                          title: MediaQuery.of(context).size.width >= 900 
+                            ? const Text("Sair", style: TextStyle(color: Colors.white70, fontSize: 13)) 
+                            : null,
+                          onTap: () => ref.read(authProvider.notifier).logout(),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  const Divider(color: Colors.white10, height: 1),
+                  
+                  // User Profile Mini
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        const CircleAvatar(
+                          radius: 16,
+                          backgroundColor: NormatiqColors.accent500,
+                          child: Text("JL", style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold, color: NormatiqColors.primary600)),
+                        ),
+                        if (MediaQuery.of(context).size.width >= 900) ...[
+                          const SizedBox(width: 12),
+                          const Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text("Juan Ladeira", style: TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.bold)),
+                                Text("Admin", style: TextStyle(color: Colors.white54, fontSize: 11)),
+                              ],
+                            ),
+                          ),
+                        ]
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          Expanded(child: navigationShell),
+        ],
+      ),
+      bottomNavigationBar: isWide
+          ? null
+          : BottomNavigationBar(
+              type: BottomNavigationBarType.fixed,
+              currentIndex: navigationShell.currentIndex,
+              selectedItemColor: NormatiqColors.primary600,
+              unselectedItemColor: NormatiqColors.neutral400,
+              onTap: (index) => navigationShell.goBranch(index),
+              items: const [
+                BottomNavigationBarItem(icon: Icon(Icons.grid_view), label: 'Início'),
+                BottomNavigationBarItem(icon: Icon(Icons.straighten), label: 'Ops'),
+                BottomNavigationBarItem(icon: Icon(Icons.science), label: 'Lab'),
+                BottomNavigationBarItem(icon: Icon(Icons.people), label: 'Clientes'),
+                BottomNavigationBarItem(icon: Icon(Icons.group), label: 'Usuários'),
+              ],
+            ),
+    );
+  }
+}

--- a/frontend/apps/lab_app/lib/features/settings/users_page.dart
+++ b/frontend/apps/lab_app/lib/features/settings/users_page.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:normatiq_ui/normatiq_ui.dart';
+import 'users_provider.dart';
+
+class UsersPage extends ConsumerWidget {
+  const UsersPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final usersAsync = ref.watch(usersProvider);
+
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      appBar: AppBar(
+        title: const Text("Gestão de Equipe", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+        backgroundColor: theme.colorScheme.surface,
+        surfaceTintColor: Colors.transparent,
+      ),
+      body: usersAsync.when(
+        data: (users) => _buildList(context, ref, users),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => Center(child: Text("Erro ao carregar equipe: $e")),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _showInviteDialog(context, ref),
+        backgroundColor: theme.colorScheme.primary,
+        foregroundColor: theme.colorScheme.onPrimary,
+        icon: const Icon(Icons.person_add_outlined),
+        label: const Text("Convidar"),
+      ),
+    );
+  }
+
+  Widget _buildList(BuildContext context, WidgetRef ref, List<LabUser> users) {
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: users.length,
+      separatorBuilder: (context, index) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final user = users[index];
+        return Card(
+          margin: EdgeInsets.zero,
+          child: ListTile(
+            leading: CircleAvatar(
+              backgroundColor: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+              child: Text(
+                user.nome.substring(0, 1).toUpperCase(),
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.primary, 
+                  fontWeight: FontWeight.bold
+                ),
+              ),
+            ),
+            title: Text(user.nome, style: const TextStyle(fontWeight: FontWeight.w600)),
+            subtitle: Text(
+              user.email, 
+              style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6))
+            ),
+            trailing: _buildRoleBadge(context, user.role),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildRoleBadge(BuildContext context, String role) {
+    final color = role == 'admin' ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurface.withOpacity(0.5);
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withOpacity(0.2)),
+      ),
+      child: Text(
+        role.toUpperCase(),
+        style: TextStyle(color: color, fontSize: 10, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  void _showInviteDialog(BuildContext context, WidgetRef ref) {
+    final emailController = TextEditingController();
+    final nameController = TextEditingController();
+    String selectedRole = 'technician';
+
+    showDialog(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          backgroundColor: Theme.of(context).colorScheme.surface,
+          title: const Text("Convidar Novo Membro"),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                decoration: const InputDecoration(labelText: "Nome Completo"),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: emailController,
+                decoration: const InputDecoration(labelText: "E-mail"),
+                keyboardType: TextInputType.emailAddress,
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                value: selectedRole,
+                dropdownColor: Theme.of(context).colorScheme.surface,
+                decoration: const InputDecoration(labelText: "Cargo"),
+                items: const [
+                  DropdownMenuItem(value: 'admin', child: Text("Administrador")),
+                  DropdownMenuItem(value: 'technician', child: Text("Técnico")),
+                  DropdownMenuItem(value: 'attendant', child: Text("Atendente")),
+                ],
+                onChanged: (v) => setState(() => selectedRole = v!),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(context), child: const Text("Cancelar")),
+            ElevatedButton(
+              onPressed: () async {
+                try {
+                  await ref.read(usersProvider.notifier).inviteUser(
+                    emailController.text,
+                    nameController.text,
+                    selectedRole,
+                  );
+                  Navigator.pop(context);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text("Convite enviado com sucesso!")),
+                  );
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text("Erro ao enviar convite: $e"), 
+                      backgroundColor: NormatiqColors.danger700
+                    ),
+                  );
+                }
+              },
+              child: const Text("Enviar Convite"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/apps/lab_app/lib/features/settings/users_provider.dart
+++ b/frontend/apps/lab_app/lib/features/settings/users_provider.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/api/client.dart';
+import 'package:dio/dio.dart';
+import 'dart:developer' as dev;
+
+class LabUser {
+  final int id;
+  final String email;
+  final String nome;
+  final String role;
+  final bool isActive;
+
+  LabUser({
+    required this.id,
+    required this.email,
+    required this.nome,
+    required this.role,
+    required this.isActive,
+  });
+
+  factory LabUser.fromJson(Map<String, dynamic> json) {
+    return LabUser(
+      id: json['id'],
+      email: json['email'],
+      nome: json['nome'],
+      role: json['role'],
+      isActive: json['is_active'],
+    );
+  }
+}
+
+class UsersNotifier extends StateNotifier<AsyncValue<List<LabUser>>> {
+  final ApiClient _apiClient;
+
+  UsersNotifier(this._apiClient) : super(const AsyncValue.loading()) {
+    fetchUsers();
+  }
+
+  Future<void> fetchUsers() async {
+    state = const AsyncValue.loading();
+    try {
+      dev.log("Buscando usuários em /api/users");
+      // Removida barra final para evitar problemas de redirect no FastAPI
+      final response = await _apiClient.dio.get('/api/users');
+      final list = (response.data as List).map((e) => LabUser.fromJson(e)).toList();
+      state = AsyncValue.data(list);
+      dev.log("Sucesso: ${list.length} usuários encontrados");
+    } on DioException catch (e) {
+      dev.log("Erro Dio ao buscar usuários: ${e.response?.statusCode} - ${e.message}");
+      state = AsyncValue.error(e, StackTrace.current);
+    } catch (e, st) {
+      dev.log("Erro inesperado ao buscar usuários: $e");
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> inviteUser(String email, String nome, String role) async {
+    try {
+      await _apiClient.dio.post('/api/users/invite', data: {
+        'email': email,
+        'nome': nome,
+        'role': role,
+      });
+      await fetchUsers(); 
+    } catch (e) {
+      dev.log("Erro ao convidar: $e");
+      rethrow;
+    }
+  }
+}
+
+final usersProvider = StateNotifierProvider<UsersNotifier, AsyncValue<List<LabUser>>>((ref) {
+  final apiClient = ref.watch(apiClientProvider);
+  return UsersNotifier(apiClient);
+});

--- a/frontend/apps/lab_app/lib/main.dart
+++ b/frontend/apps/lab_app/lib/main.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:normatiq_ui/normatiq_ui.dart';
+import 'features/auth/login_page.dart';
+import 'features/auth/accept_invite_page.dart';
+import 'features/auth/auth_provider.dart';
+import 'features/home/main_shell.dart';
+import 'features/home/dashboard_page.dart';
+import 'features/settings/users_page.dart';
+import 'core/theme/theme_provider.dart';
+
+void main() {
+  runApp(
+    const ProviderScope(
+      child: NormatiqLabApp(),
+    ),
+  );
+}
+
+// Provedor do GoRouter integrado com Auth
+final _rootNavigatorKey = GlobalKey<NavigatorState>();
+final _shellNavigatorHomeKey = GlobalKey<NavigatorState>(debugLabel: 'home');
+final _shellNavigatorOpsKey = GlobalKey<NavigatorState>(debugLabel: 'ops');
+final _shellNavigatorLabKey = GlobalKey<NavigatorState>(debugLabel: 'lab');
+final _shellNavigatorClientsKey = GlobalKey<NavigatorState>(debugLabel: 'clients');
+final _shellNavigatorMoreKey = GlobalKey<NavigatorState>(debugLabel: 'more');
+
+final _routerProvider = Provider<GoRouter>((ref) {
+  final authState = ref.watch(authProvider);
+
+  return GoRouter(
+    navigatorKey: _rootNavigatorKey,
+    initialLocation: '/',
+    redirect: (context, state) {
+      final isPublicRoute = state.matchedLocation == '/login' || state.matchedLocation == '/accept-invite';
+      final isAuthenticated = authState.status == AuthStatus.authenticated;
+
+      if (!isAuthenticated && !isPublicRoute) return '/login';
+      if (isAuthenticated && state.matchedLocation == '/login') return '/';
+
+      return null;
+    },
+    routes: [
+      GoRoute(
+        path: '/login',
+        builder: (context, state) => const LoginPage(),
+      ),
+      GoRoute(
+        path: '/accept-invite',
+        builder: (context, state) {
+          final token = state.uri.queryParameters['token'] ?? '';
+          return AcceptInvitePage(token: token);
+        },
+      ),
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) {
+          return MainShell(navigationShell: navigationShell);
+        },
+        branches: [
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorHomeKey,
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (context, state) => const DashboardPage(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorOpsKey,
+            routes: [
+              GoRoute(
+                path: '/operations',
+                builder: (context, state) => const Scaffold(
+                  body: Center(child: Text("Operações (Calibrações)")),
+                ),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorLabKey,
+            routes: [
+              GoRoute(
+                path: '/laboratory',
+                builder: (context, state) => const Scaffold(
+                  body: Center(child: Text("Laboratório (Padrões)")),
+                ),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorClientsKey,
+            routes: [
+              GoRoute(
+                path: '/clients',
+                builder: (context, state) => const Scaffold(
+                  body: Center(child: Text("Clientes & Instrumentos")),
+                ),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _shellNavigatorMoreKey,
+            routes: [
+              GoRoute(
+                path: '/more',
+                builder: (context, state) => const UsersPage(),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+});
+
+class NormatiqLabApp extends ConsumerWidget {
+  const NormatiqLabApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(_routerProvider);
+    final themeMode = ref.watch(themeModeProvider);
+
+    return MaterialApp.router(
+      title: 'Normatiq Lab',
+      theme: NormatiqTheme.light,
+      darkTheme: NormatiqTheme.dark,
+      themeMode: themeMode,
+      routerConfig: router,
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}

--- a/frontend/lib/core/api/client.dart
+++ b/frontend/lib/core/api/client.dart
@@ -1,0 +1,56 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class ApiClient {
+  late Dio dio;
+  final storage = const FlutterSecureStorage();
+
+  ApiClient() {
+    dio = Dio(
+      BaseOptions(
+        // URL da nossa API FastAPI (usando localhost para Web, 
+        // mas para Android Emulator seria 10.0.2.2)
+        baseUrl: 'http://localhost:8000',
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 3),
+      ),
+    );
+
+    // Adiciona interceptor para incluir o token JWT em todas as requisições
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          final token = await storage.read(key: 'access_token');
+          if (token != null) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
+          return handler.next(options);
+        },
+        onError: (DioException e, handler) {
+          if (e.response?.statusCode == 401) {
+            // Aqui poderíamos tratar o logout automático
+            print('Token expirado ou inválido');
+          }
+          return handler.next(e);
+        },
+      ),
+    );
+  }
+
+  // Método simples para login
+  Future<Map<String, dynamic>> login(String username, String password) async {
+    try {
+      final response = await dio.post('/auth/token', data: {
+        'username': username,
+        'password': password,
+      });
+      
+      final token = response.data['access_token'];
+      await storage.write(key: 'access_token', value: token);
+      
+      return response.data;
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        // This is the theme of your application.
+        //
+        // TRY THIS: Try running your application with "flutter run". You'll see
+        // the application has a purple toolbar. Then, without quitting the app,
+        // try changing the seedColor in the colorScheme below to Colors.green
+        // and then invoke "hot reload" (save your changes or press the "hot
+        // reload" button in a Flutter-supported IDE, or press "r" if you used
+        // the command line to start the app).
+        //
+        // Notice that the counter didn't reset back to zero; the application
+        // state is not lost during the reload. To reset the state, use hot
+        // restart instead.
+        //
+        // This works for code too, not just values: Most code changes can be
+        // tested with just a hot reload.
+        colorScheme: .fromSeed(seedColor: Colors.deepPurple),
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+
+  // This widget is the home page of your application. It is stateful, meaning
+  // that it has a State object (defined below) that contains fields that affect
+  // how it looks.
+
+  // This class is the configuration for the state. It holds the values (in this
+  // case the title) provided by the parent (in this case the App widget) and
+  // used by the build method of the State. Fields in a Widget subclass are
+  // always marked "final".
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      // This call to setState tells the Flutter framework that something has
+      // changed in this State, which causes it to rerun the build method below
+      // so that the display can reflect the updated values. If we changed
+      // _counter without calling setState(), then the build method would not be
+      // called again, and so nothing would appear to happen.
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // This method is rerun every time setState is called, for instance as done
+    // by the _incrementCounter method above.
+    //
+    // The Flutter framework has been optimized to make rerunning build methods
+    // fast, so that you can just rebuild anything that needs updating rather
+    // than having to individually change instances of widgets.
+    return Scaffold(
+      appBar: AppBar(
+        // TRY THIS: Try changing the color here to a specific color (to
+        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
+        // change color while the other colors stay the same.
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        // Here we take the value from the MyHomePage object that was created by
+        // the App.build method, and use it to set our appbar title.
+        title: Text(widget.title),
+      ),
+      body: Center(
+        // Center is a layout widget. It takes a single child and positions it
+        // in the middle of the parent.
+        child: Column(
+          // Column is also a layout widget. It takes a list of children and
+          // arranges them vertically. By default, it sizes itself to fit its
+          // children horizontally, and tries to be as tall as its parent.
+          //
+          // Column has various properties to control how it sizes itself and
+          // how it positions its children. Here we use mainAxisAlignment to
+          // center the children vertically; the main axis here is the vertical
+          // axis because Columns are vertical (the cross axis would be
+          // horizontal).
+          //
+          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
+          // action in the IDE, or press "p" in the console), to see the
+          // wireframe for each widget.
+          mainAxisAlignment: .center,
+          children: [
+            const Text('You have pushed the button this many times:'),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/frontend/packages/normatiq_api/lib/normatiq_api.dart
+++ b/frontend/packages/normatiq_api/lib/normatiq_api.dart
@@ -1,0 +1,5 @@
+/// A Calculator.
+class Calculator {
+  /// Returns [value] plus 1.
+  int addOne(int value) => value + 1;
+}

--- a/frontend/packages/normatiq_domain/lib/normatiq_domain.dart
+++ b/frontend/packages/normatiq_domain/lib/normatiq_domain.dart
@@ -1,0 +1,5 @@
+/// A Calculator.
+class Calculator {
+  /// Returns [value] plus 1.
+  int addOne(int value) => value + 1;
+}

--- a/frontend/packages/normatiq_ui/lib/normatiq_ui.dart
+++ b/frontend/packages/normatiq_ui/lib/normatiq_ui.dart
@@ -1,0 +1,5 @@
+library normatiq_ui;
+
+export 'src/tokens.dart';
+export 'src/theme.dart';
+export 'src/widgets.dart';

--- a/frontend/packages/normatiq_ui/lib/src/theme.dart
+++ b/frontend/packages/normatiq_ui/lib/src/theme.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'tokens.dart';
+
+class NormatiqTheme {
+  static ThemeData get light {
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.light,
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: NormatiqColors.primary600,
+        primary: NormatiqColors.primary600,
+        secondary: NormatiqColors.accent500,
+        surface: Colors.white,
+      ),
+      scaffoldBackgroundColor: NormatiqColors.neutral50,
+      cardTheme: CardThemeData(
+        color: Colors.white,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(NormatiqRadius.md),
+          side: const BorderSide(color: NormatiqColors.neutral200),
+        ),
+      ),
+      appBarTheme: const AppBarTheme(
+        backgroundColor: Colors.white,
+        foregroundColor: NormatiqColors.neutral900,
+        elevation: 0,
+      ),
+    );
+  }
+
+  static ThemeData get dark {
+    const darkSurface = Color(0xFF0F172A); // Slate 950
+    const darkCard = Color(0xFF1E293B); // Slate 800
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.dark,
+      colorScheme: ColorScheme.fromSeed(
+        brightness: Brightness.dark,
+        seedColor: NormatiqColors.primary600,
+        primary: NormatiqColors.accent500,
+        secondary: NormatiqColors.accent500,
+        surface: darkSurface,
+        onSurface: Colors.white,
+        surfaceContainer: darkCard,
+      ),
+      scaffoldBackgroundColor: darkSurface,
+      dividerColor: Colors.white10,
+      cardTheme: CardThemeData(
+        color: darkCard,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(NormatiqRadius.md),
+          side: BorderSide(color: Colors.white.withOpacity(0.05)),
+        ),
+      ),
+      appBarTheme: const AppBarTheme(
+        backgroundColor: darkSurface,
+        foregroundColor: Colors.white,
+        elevation: 0,
+      ),
+      textTheme: const TextTheme(
+        headlineLarge: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+        bodyMedium: TextStyle(color: Color(0xFF94A3B8)),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: darkCard,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(NormatiqRadius.md),
+          borderSide: BorderSide(color: Colors.white.withOpacity(0.1)),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/packages/normatiq_ui/lib/src/tokens.dart
+++ b/frontend/packages/normatiq_ui/lib/src/tokens.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class NormatiqColors {
+  // Primary — Cobalt Blue
+  static const Color primary50 = Color(0xFFEEF3FB);
+  static const Color primary100 = Color(0xFFD4E1F5);
+  static const Color primary200 = Color(0xFFA9C3EB);
+  static const Color primary300 = Color(0xFF7EA5E1);
+  static const Color primary400 = Color(0xFF5387D7);
+  static const Color primary500 = Color(0xFF2A6AC8);
+  static const Color primary600 = Color(0xFF1A3A6C); // ← brand primary
+  static const Color primary700 = Color(0xFF152E56);
+  static const Color primary800 = Color(0xFF102240);
+  static const Color primary900 = Color(0xFF0A162A);
+
+  // Accent — Teal
+  static const Color accent50 = Color(0xFFE6FAFA);
+  static const Color accent100 = Color(0xFFB3F0EE);
+  static const Color accent500 = Color(0xFF00B5A4); // ← brand accent
+
+  // Neutral — Cool Gray
+  static const Color neutral0 = Color(0xFFFFFFFF);
+  static const Color neutral50 = Color(0xFFF8FAFC);
+  static const Color neutral100 = Color(0xFFF1F4F8);
+  static const Color neutral200 = Color(0xFFE2E8F0);
+  static const Color neutral300 = Color(0xFFCBD5E1);
+  static const Color neutral400 = Color(0xFF94A3B8);
+  static const Color neutral500 = Color(0xFF64748B);
+  static const Color neutral600 = Color(0xFF475569);
+  static const Color neutral900 = Color(0xFF0F172A);
+
+  // Semantic
+  static const Color success50 = Color(0xFFF0FDF4);
+  static const Color success700 = Color(0xFF15803D);
+  static const Color warning50 = Color(0xFFFFFBEB);
+  static const Color warning700 = Color(0xFFB45309);
+  static const Color danger50 = Color(0xFFFEF2F2);
+  static const Color danger700 = Color(0xFFB91C1C);
+  static const Color info50 = Color(0xFFEFF6FF);
+  static const Color info700 = Color(0xFF1D4ED8);
+}
+
+class NormatiqSpacing {
+  static const double s1 = 4.0;
+  static const double s2 = 8.0;
+  static const double s3 = 12.0;
+  static const double s4 = 16.0;
+  static const double s5 = 20.0;
+  static const double s6 = 24.0;
+  static const double s8 = 32.0;
+}
+
+class NormatiqRadius {
+  static const double sm = 4.0;
+  static const double md = 6.0;
+  static const double lg = 8.0;
+  static const double xl = 12.0;
+  static const double full = 9999.0;
+}

--- a/frontend/packages/normatiq_ui/lib/src/widgets.dart
+++ b/frontend/packages/normatiq_ui/lib/src/widgets.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'tokens.dart';
+
+class NormatiqLogo extends StatelessWidget {
+  final double size;
+  final bool isDark;
+  final bool showText;
+
+  const NormatiqLogo({
+    super.key,
+    this.size = 32,
+    this.isDark = false,
+    this.showText = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final primaryColor = isDark ? Colors.white : NormatiqColors.primary600;
+    final iconBg = isDark ? NormatiqColors.accent500 : NormatiqColors.primary600;
+    final barColor = isDark ? NormatiqColors.primary600 : NormatiqColors.accent500;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: size,
+          height: size,
+          padding: EdgeInsets.all(size * 0.15),
+          decoration: BoxDecoration(
+            color: iconBg,
+            borderRadius: BorderRadius.circular(size * 0.2),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              _buildBar(size * 0.4, barColor),
+              const SizedBox(width: 2),
+              _buildBar(size * 0.6, barColor),
+              const SizedBox(width: 2),
+              _buildBar(size * 0.25, Colors.white.withOpacity(0.6)),
+              const SizedBox(width: 2),
+              _buildBar(size * 0.15, Colors.white.withOpacity(0.4)),
+            ],
+          ),
+        ),
+        if (showText) ...[
+          const SizedBox(width: 12),
+          Text(
+            "Normatiq",
+            style: TextStyle(
+              color: primaryColor,
+              fontSize: size * 0.6,
+              fontWeight: FontWeight.w600,
+              letterSpacing: -0.5,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildBar(double height, Color color) {
+    return Expanded(
+      child: Container(
+        height: height,
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(1),
+        ),
+      ),
+    );
+  }
+}
+
+class NormatiqStatCard extends StatelessWidget {
+  final String value;
+  final String label;
+  final String? sub;
+  final Color? color;
+  final VoidCallback? onTap;
+
+  const NormatiqStatCard({
+    super.key,
+    required this.value,
+    required this.label,
+    this.sub,
+    this.color,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(NormatiqRadius.md),
+        child: Padding(
+          padding: const EdgeInsets.all(18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                value,
+                style: TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w700,
+                  color: color ?? Theme.of(context).colorScheme.primary,
+                  letterSpacing: -1,
+                  height: 1,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+              if (sub != null) ...[
+                const SizedBox(height: 2),
+                Text(
+                  sub!,
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix crítico**: `.gitignore` raiz tinha `lib/` (template Python) que ignorava silenciosamente todo o código-fonte Flutter (`lib/` dos pacotes e do app). Corrigido para `/lib/` (só raiz).
- **12-factor config**: `client.dart` agora lê `API_URL` via `String.fromEnvironment` com fallback para `localhost:8000` em dev.
- **Prod Dockerfile** (`compose/prod/frontend/Dockerfile`): multi-stage — Flutter `stable` compila com `--dart-define=API_URL=https://api.z3ndocs.uk`, nginx serve os estáticos.
- **nginx.conf**: SPA fallback (`try_files $uri /index.html`), gzip, cache de 1 ano em assets com hash.
- **docker-compose.prod.yml**: serviço `frontend` exposto em `z3ndocs.uk` via Traefik + Let's Encrypt.
- **Dev Dockerfile**: `--dart-define=API_URL=http://localhost:8000` explícito no `CMD`.

## Como funciona em prod

```
z3ndocs.uk  →  Traefik  →  frontend (nginx:80)
                            └── build/web/ (Flutter compilado com API_URL=https://api.z3ndocs.uk)

api.z3ndocs.uk  →  Traefik  →  api (uvicorn:8000)
```

## Test plan

- [ ] `make prod-build` conclui sem erros (Flutter build web leva ~5-10 min na primeira vez)
- [ ] `z3ndocs.uk` abre a tela de login do Flutter Web com HTTPS
- [ ] Login faz request para `https://api.z3ndocs.uk` (verificar no DevTools → Network)
- [ ] Navegação entre rotas não retorna 404 (SPA fallback funcionando)
- [ ] `http://z3ndocs.uk` redireciona para HTTPS (Traefik entrypoint websecure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)